### PR TITLE
Fix Prompt Ideas + Img

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "WebSearch"
+    ]
+  }
+}

--- a/src/main/java/com/simbiocreacion/resource/controller/SymbiocreationController.java
+++ b/src/main/java/com/simbiocreacion/resource/controller/SymbiocreationController.java
@@ -318,25 +318,17 @@ public class SymbiocreationController {
                                 .flatMap(node -> this.llmService.getIdeasForGroupFromLlm(symbio, node)));
     }
 
+    // TODO [Manera recomendada]: Al actualizar Spring AI y revertir getImageFromLlm a Mono<Image>,
+    //  cambiar este método para recibir Image y usar UrlResource con image.getUrl() como antes.
     @PostMapping("/getImageFromAI")
     @ResponseBody
-    public ResponseEntity<Mono<Resource>> getImagesFromAI(@RequestBody IdeaRequest idea) {
+    public Mono<ResponseEntity<byte[]>> getImagesFromAI(@RequestBody IdeaRequest idea) {
 
-        Mono<Resource> resourceMono = this.llmService.getImageFromLlm(idea)
-                .map(image -> {
-                    URI uri = URI.create(image.getUrl());
-                    Resource resource = null;
-                    try {
-                        resource = new UrlResource(uri);
-                    } catch (MalformedURLException e) {
-                        throw new RuntimeException(e);
-                    }
-                    return resource;
-                });
-
-        return ResponseEntity.ok()
-                .contentType(MediaType.IMAGE_PNG)
-                .body(resourceMono);
+        return this.llmService.getImageFromLlm(idea)
+                .map(imageBytes -> ResponseEntity.ok()
+                        .contentType(MediaType.IMAGE_PNG)
+                        .body(imageBytes))
+                .defaultIfEmpty(ResponseEntity.notFound().build());
     }
 
     @GetMapping(value = "/getImageFromAi2", produces = MediaType.IMAGE_PNG_VALUE)

--- a/src/main/java/com/simbiocreacion/resource/controller/SymbiocreationController.java
+++ b/src/main/java/com/simbiocreacion/resource/controller/SymbiocreationController.java
@@ -180,24 +180,37 @@ public class SymbiocreationController {
     }
 
     @GetMapping("/getAllPublic/{page}")
-    public Flux<Symbiocreation> findPublicAll(@PathVariable int page) {
-        // Pageable sortedByPriceDescNameAsc =
-        //  PageRequest.of(0, 5, Sort.by("price").descending().and(Sort.by("name")));
+    public Flux<Symbiocreation> findPublicAll(@PathVariable int page,
+                                               @RequestParam(required = false) String name) {
         Pageable paging = PageRequest.of(page, 20);
+        if (name != null && !name.isBlank()) {
+            return symbioService.findByVisibilityAndNameContainingIgnoreCase("public", name, paging)
+                    .flatMap(this::completeUsers);
+        }
         return symbioService.findByVisibilityOrderByLastModifiedDesc("public", paging)
                 .flatMap(this::completeUsers);
     }
 
     @GetMapping("/getUpcomingPublic/{page}")
-    public Flux<Symbiocreation> findPublicUpcoming(@PathVariable int page) {
+    public Flux<Symbiocreation> findPublicUpcoming(@PathVariable int page,
+                                                    @RequestParam(required = false) String name) {
         Pageable paging = PageRequest.of(page, 20, Sort.by("dateTime").ascending());
+        if (name != null && !name.isBlank()) {
+            return symbioService.findByVisibilityAndDateTimeGreaterThanEqualAndNameContainingIgnoreCase("public", new Date(), name, paging)
+                    .flatMap(this::completeUsers);
+        }
         return symbioService.findByVisibilityAndDateTimeGreaterThanEqual("public", new Date(), paging)
                 .flatMap(this::completeUsers);
     }
 
     @GetMapping("/getPastPublic/{page}")
-    public Flux<Symbiocreation> findPublicPast(@PathVariable int page) {
+    public Flux<Symbiocreation> findPublicPast(@PathVariable int page,
+                                                @RequestParam(required = false) String name) {
         Pageable paging = PageRequest.of(page, 20, Sort.by("dateTime").descending());
+        if (name != null && !name.isBlank()) {
+            return symbioService.findByVisibilityAndDateTimeLessThanEqualAndNameContainingIgnoreCase("public", new Date(), name, paging)
+                    .flatMap(this::completeUsers);
+        }
         return symbioService.findByVisibilityAndDateTimeLessThanEqual("public", new Date(), paging)
                 .flatMap(this::completeUsers);
     }

--- a/src/main/java/com/simbiocreacion/resource/repository/SymbiocreationRepository.java
+++ b/src/main/java/com/simbiocreacion/resource/repository/SymbiocreationRepository.java
@@ -25,6 +25,10 @@ public interface SymbiocreationRepository extends ReactiveMongoRepository<Symbio
     @Query(fields = "{'graph': 0}")
     Flux<Symbiocreation> findByVisibilityOrderByLastModifiedDesc(String visibility, Pageable pageable);
 
+    // Search by name (case-insensitive, partial match)
+    @Query(value = "{'visibility': ?0, 'name': {$regex: ?1, $options: 'i'}}", fields = "{'graph': 0}")
+    Flux<Symbiocreation> findByVisibilityAndNameContainingIgnoreCase(String visibility, String name, Pageable pageable);
+
     //@Query(value = "{'visibility': ?0, 'dateTime' : {'$gt' : ?1}}", fields = "{'graph': 0}", sort = "{dateTime: 1}")
     //Flux<Symbiocreation> findUpcomingByVisibility(String visibility, Date now);
 
@@ -32,8 +36,14 @@ public interface SymbiocreationRepository extends ReactiveMongoRepository<Symbio
     @Query(fields = "{'graph': 0}")
     Flux<Symbiocreation> findByVisibilityAndDateTimeLessThanEqual(String visibility, Date now, Pageable pageable);
 
+    @Query(value = "{'visibility': ?0, 'dateTime': {'$lte': ?1}, 'name': {$regex: ?2, $options: 'i'}}", fields = "{'graph': 0}")
+    Flux<Symbiocreation> findByVisibilityAndDateTimeLessThanEqualAndNameContainingIgnoreCase(String visibility, Date now, String name, Pageable pageable);
+
     @Query(fields = "{'graph': 0}")
     Flux<Symbiocreation> findByVisibilityAndDateTimeGreaterThanEqual(String visibility, Date now, Pageable pageable);
+
+    @Query(value = "{'visibility': ?0, 'dateTime': {'$gte': ?1}, 'name': {$regex: ?2, $options: 'i'}}", fields = "{'graph': 0}")
+    Flux<Symbiocreation> findByVisibilityAndDateTimeGreaterThanEqualAndNameContainingIgnoreCase(String visibility, Date now, String name, Pageable pageable);
 
     Mono<Long> countByVisibility(String visibility);
 

--- a/src/main/java/com/simbiocreacion/resource/service/ILlmService.java
+++ b/src/main/java/com/simbiocreacion/resource/service/ILlmService.java
@@ -5,7 +5,6 @@ import com.simbiocreacion.resource.dto.IdeaRequest;
 import com.simbiocreacion.resource.dto.TrendAiResponse;
 import com.simbiocreacion.resource.model.Node;
 import com.simbiocreacion.resource.model.Symbiocreation;
-import org.springframework.ai.image.Image;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -16,7 +15,9 @@ public interface ILlmService {
 
     Mono<List<IdeaAiResponse>> getIdeasForGroupFromLlm(Symbiocreation symbiocreation, Node group);
 
-    Mono<Image> getImageFromLlm(IdeaRequest idea);
+    // TODO [Manera recomendada]: Al actualizar Spring AI a una versión que soporte gpt-image-1,
+    //  revertir a Mono<Image> y usar ImageModel directamente en vez del WebClient manual.
+    Mono<byte[]> getImageFromLlm(IdeaRequest idea);
 
     Mono<List<TrendAiResponse>> getTrendsForSymbioFromLlm(Symbiocreation symbiocreation);
 }

--- a/src/main/java/com/simbiocreacion/resource/service/ISymbiocreationService.java
+++ b/src/main/java/com/simbiocreacion/resource/service/ISymbiocreationService.java
@@ -26,9 +26,15 @@ public interface ISymbiocreationService {
 
     Flux<Symbiocreation> findByVisibilityOrderByLastModifiedDesc(String visibility, Pageable pageable);
 
+    Flux<Symbiocreation> findByVisibilityAndNameContainingIgnoreCase(String visibility, String name, Pageable pageable);
+
     Flux<Symbiocreation> findByVisibilityAndDateTimeLessThanEqual(String visibility, Date now, Pageable pageable);
 
+    Flux<Symbiocreation> findByVisibilityAndDateTimeLessThanEqualAndNameContainingIgnoreCase(String visibility, Date now, String name, Pageable pageable);
+
     Flux<Symbiocreation> findByVisibilityAndDateTimeGreaterThanEqual(String visibility, Date now, Pageable pageable);
+
+    Flux<Symbiocreation> findByVisibilityAndDateTimeGreaterThanEqualAndNameContainingIgnoreCase(String visibility, Date now, String name, Pageable pageable);
 
     Mono<Symbiocreation> update(Symbiocreation e);
 

--- a/src/main/java/com/simbiocreacion/resource/service/LlmService.java
+++ b/src/main/java/com/simbiocreacion/resource/service/LlmService.java
@@ -1,5 +1,7 @@
 package com.simbiocreacion.resource.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.simbiocreacion.resource.dto.IdeaAiResponse;
 import com.simbiocreacion.resource.dto.IdeaRequest;
 import com.simbiocreacion.resource.dto.TrendAiResponse;
@@ -13,19 +15,17 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.chat.prompt.PromptTemplate;
 import org.springframework.ai.converter.BeanOutputConverter;
-import org.springframework.ai.image.Image;
-import org.springframework.ai.image.ImageMessage;
-import org.springframework.ai.image.ImageModel;
-import org.springframework.ai.image.ImagePrompt;
-import org.springframework.ai.openai.OpenAiImageOptions;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +38,12 @@ import java.util.stream.Collectors;
 public class LlmService implements ILlmService {
 
     private final ChatClient chatClient;
-    private final ImageModel imageModel;
+
+    // TODO [Manera recomendada]: Al actualizar Spring AI a una versión que soporte gpt-image-1,
+    //  reemplazar este WebClient por ImageModel de Spring AI:
+    //  private final ImageModel imageModel;
+    private final WebClient openAiWebClient;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Value("classpath:/prompts/system-for-symbio-ideas.md")
     private Resource systemForSymbioIdeas;
@@ -65,7 +70,7 @@ public class LlmService implements ILlmService {
     private static final String USER_IDEA_TEMPLATE = """
             Título: %s
             Descripción: %s
-            
+
             """;
     private static final String USER_QUERY_TEMPLATE_1 = """
             Give me three new ideas for the topic given to you.
@@ -86,16 +91,27 @@ public class LlmService implements ILlmService {
     private static final String NO_IDEAS_FOR_SYMBIO_MSG = "Para usar esta funcionalidad, los participantes deben agregar al menos una idea a la sesión. Una vez que haya ideas disponibles, la IA podrá generar nuevas sugerencias basadas en ellas.";
     private static final String NO_IDEAS_FOR_GROUP_MSG = "Para consolidar ideas del grupo, los participantes deben agregar al menos una idea. Una vez que haya ideas disponibles, la IA podrá generar sugerencias consolidadas.";
 
-    public LlmService(ChatClient.Builder builder, ImageModel imageModel) {
+    // TODO [Manera recomendada]: Al actualizar Spring AI, cambiar la firma del constructor a:
+    //  public LlmService(ChatClient.Builder builder, ImageModel imageModel)
+    //  y eliminar el WebClient y apiKey.
+    public LlmService(ChatClient.Builder builder,
+                      @Value("${spring.ai.openai.api-key}") String openAiApiKey) {
         this.chatClient = builder.build();
-        this.imageModel = imageModel;
+        this.openAiWebClient = WebClient.builder()
+                .baseUrl("https://api.openai.com/v1")
+                .defaultHeader("Authorization", "Bearer " + openAiApiKey)
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(10 * 1024 * 1024)) // 10 MB para imágenes base64
+                .build();
     }
 
     @Override
     public Mono<List<IdeaAiResponse>> getIdeasForSymbioFromLlm(Symbiocreation symbiocreation) {
+        log.debug("Getting ideas from LLM for symbiocreation: {}", symbiocreation.getId());
         List<Idea> existingIdeas = getIdeasFromSymbiocreation(symbiocreation, 3);
+        log.debug("Found {} existing ideas in symbiocreation", existingIdeas.size());
 
         if (existingIdeas.isEmpty()) {
+            log.info("No existing ideas found for symbiocreation: {}, returning default message", symbiocreation.getId());
             return Mono.just(List.of(new IdeaAiResponse(NO_IDEAS_TITLE, NO_IDEAS_FOR_SYMBIO_MSG)));
         }
 
@@ -127,27 +143,34 @@ public class LlmService implements ILlmService {
 
             Prompt prompt = new Prompt(List.of(
                     new SystemMessage(systemForSymbioIdeas), userProblem, userIdeas, userQuery));
+            log.debug("Sending prompt to LLM for symbiocreation: {}", symbiocreation.getId());
             String content = chatClient.prompt(prompt).call().content();
+            log.debug("Received response from LLM: {}", content);
             List<IdeaAiResponse> llmResponse = outputConverter.convert(content);
+            log.debug("Parsed {} ideas from LLM response", llmResponse != null ? llmResponse.size() : 0);
 
             return validateResponse(llmResponse);
         })
         .subscribeOn(Schedulers.boundedElastic())
         .onErrorResume(e -> {
-            log.error("Error getting ideas from LLM for symbiocreation: {}", symbiocreation.getId(), e);
+            log.error("Error getting ideas from LLM for symbiocreation: {}. Error type: {}. Message: {}",
+                    symbiocreation.getId(), e.getClass().getSimpleName(), e.getMessage(), e);
             return Mono.just(Collections.emptyList());
         });
     }
 
     @Override
     public Mono<List<IdeaAiResponse>> getIdeasForGroupFromLlm(Symbiocreation symbiocreation, Node group) {
+        log.debug("Getting ideas from LLM for group: {} in symbiocreation: {}", group.getId(), symbiocreation.getId());
         List<Idea> groupIdeas = group.getChildren().stream()
                 .map(Node::getIdea)
                 .filter(Objects::nonNull)
                 .filter(TITLE_OR_DESCRIPTION_EXISTS_PREDICATE)
                 .toList();
+        log.debug("Found {} ideas in group", groupIdeas.size());
 
         if (groupIdeas.isEmpty()) {
+            log.info("No ideas found in group: {}, returning default message", group.getId());
             return Mono.just(List.of(new IdeaAiResponse(NO_IDEAS_TITLE, NO_IDEAS_FOR_GROUP_MSG)));
         }
 
@@ -179,40 +202,76 @@ public class LlmService implements ILlmService {
 
             Prompt prompt = new Prompt(List.of(
                     new SystemMessage(systemForGroupIdeas), userSession, userIdeas, userQuery));
+            log.debug("Sending prompt to LLM for group: {}", group.getId());
             String content = chatClient.prompt(prompt).call().content();
+            log.debug("Received response from LLM: {}", content);
             List<IdeaAiResponse> llmResponse = outputConverter.convert(content);
+            log.debug("Parsed {} ideas from LLM response", llmResponse != null ? llmResponse.size() : 0);
 
             return validateResponse(llmResponse);
         })
         .subscribeOn(Schedulers.boundedElastic())
         .onErrorResume(e -> {
-            log.error("Error getting ideas from LLM for group: {} in symbiocreation: {}",
-                    group.getId(), symbiocreation.getId(), e);
+            log.error("Error getting ideas from LLM for group: {} in symbiocreation: {}. Error type: {}. Message: {}",
+                    group.getId(), symbiocreation.getId(), e.getClass().getSimpleName(), e.getMessage(), e);
             return Mono.just(Collections.emptyList());
         });
     }
 
+    // TODO [Manera recomendada]: Al actualizar Spring AI a una versión que soporte gpt-image-1,
+    //  reemplazar todo este método por el uso de ImageModel de Spring AI:
+    //
+    //  @Override
+    //  public Mono<Image> getImageFromLlm(IdeaRequest idea) {
+    //      return Mono.fromCallable(() -> {
+    //          ImagePrompt imagePrompt = new ImagePrompt(
+    //              new ImageMessage(sanitizeInput(idea.title()) + "\n" + sanitizeInput(idea.description())),
+    //              OpenAiImageOptions.builder()
+    //                  .withModel("gpt-image-1")
+    //                  .withQuality("high")
+    //                  .withN(1)
+    //                  .withHeight(1024)
+    //                  .withWidth(1024)
+    //                  .build());
+    //          return imageModel.call(imagePrompt).getResult().getOutput();
+    //      })
+    //      .subscribeOn(Schedulers.boundedElastic())
+    //      .onErrorResume(e -> {
+    //          log.error("Error generating image from LLM for idea: {}", idea.title(), e);
+    //          return Mono.empty();
+    //      });
+    //  }
     @Override
-    public Mono<Image> getImageFromLlm(IdeaRequest idea) {
-        return Mono.fromCallable(() -> {
-            String sanitizedTitle = sanitizeInput(idea.title());
-            String sanitizedDescription = sanitizeInput(idea.description());
-            String messageContent = sanitizedTitle + "\n" + sanitizedDescription;
+    public Mono<byte[]> getImageFromLlm(IdeaRequest idea) {
+        String sanitizedTitle = sanitizeInput(idea.title());
+        String sanitizedDescription = sanitizeInput(idea.description());
+        String prompt = sanitizedTitle + "\n" + sanitizedDescription;
 
-            ImageMessage imageMessage = new ImageMessage(messageContent);
-            ImagePrompt imagePrompt = new ImagePrompt(imageMessage, OpenAiImageOptions.builder()
-                    .withQuality("hd")
-                    .withN(1)
-                    .withHeight(1024)
-                    .withWidth(1024)
-                    .build());
-            return imageModel.call(imagePrompt).getResult().getOutput();
-        })
-        .subscribeOn(Schedulers.boundedElastic())
-        .onErrorResume(e -> {
-            log.error("Error generating image from LLM for idea: {}", idea.title(), e);
-            return Mono.empty();
-        });
+        Map<String, Object> requestBody = Map.of(
+                "model", "gpt-image-1",
+                "prompt", prompt,
+                "n", 1,
+                "size", "1024x1024",
+                "quality", "medium"
+        );
+
+        return openAiWebClient.post()
+                .uri("/images/generations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(String.class)
+                .map(responseBody -> {
+                    try {
+                        JsonNode root = objectMapper.readTree(responseBody);
+                        String b64Data = root.path("data").get(0).path("b64_json").asText();
+                        return Base64.getDecoder().decode(b64Data);
+                    } catch (Exception e) {
+                        throw new RuntimeException("Error parsing image response from OpenAI", e);
+                    }
+                })
+                .doOnError(e -> log.error("Error generating image from OpenAI for idea: {}", idea.title(), e))
+                .onErrorResume(e -> Mono.empty());
     }
 
     @Override

--- a/src/main/java/com/simbiocreacion/resource/service/SymbiocreationService.java
+++ b/src/main/java/com/simbiocreacion/resource/service/SymbiocreationService.java
@@ -67,13 +67,28 @@ public class SymbiocreationService implements ISymbiocreationService {
     }
 
     @Override
+    public Flux<Symbiocreation> findByVisibilityAndNameContainingIgnoreCase(String visibility, String name, Pageable pageable) {
+        return symbioRepository.findByVisibilityAndNameContainingIgnoreCase(visibility, name, pageable);
+    }
+
+    @Override
     public Flux<Symbiocreation> findByVisibilityAndDateTimeLessThanEqual(String visibility, Date now, Pageable pageable) {
         return symbioRepository.findByVisibilityAndDateTimeLessThanEqual(visibility, now, pageable);
     }
 
     @Override
+    public Flux<Symbiocreation> findByVisibilityAndDateTimeLessThanEqualAndNameContainingIgnoreCase(String visibility, Date now, String name, Pageable pageable) {
+        return symbioRepository.findByVisibilityAndDateTimeLessThanEqualAndNameContainingIgnoreCase(visibility, now, name, pageable);
+    }
+
+    @Override
     public Flux<Symbiocreation> findByVisibilityAndDateTimeGreaterThanEqual(String visibility, Date now, Pageable pageable) {
         return symbioRepository.findByVisibilityAndDateTimeGreaterThanEqual(visibility, now, pageable);
+    }
+
+    @Override
+    public Flux<Symbiocreation> findByVisibilityAndDateTimeGreaterThanEqualAndNameContainingIgnoreCase(String visibility, Date now, String name, Pageable pageable) {
+        return symbioRepository.findByVisibilityAndDateTimeGreaterThanEqualAndNameContainingIgnoreCase(visibility, now, name, pageable);
     }
 
     @Override

--- a/src/main/resources/prompts/system-for-group-ideas.md
+++ b/src/main/resources/prompts/system-for-group-ideas.md
@@ -1,5 +1,6 @@
-You are an AI-powered brainstorming assistant and your job is to condense and combine different ideas into three new 
+You are an AI-powered brainstorming assistant and your job is to condense and combine different ideas into new 
 consolidated ideas, while following the line established by the session's topic and description. 
-You will be provided with many ideas, each with a title and description, and a session's topic and description. 
+You will be provided with ideas, each with a title and description, and a session's topic and description. 
 The ideas you generate should have a title and description. Ignore any missing data, and if you are not able to 
-come up with three consolidated ideas just return fewer ideas. If no ideas are passed to you, just return an empty list.
+come up with consolidated ideas just return fewer ideas. If no ideas are passed to you, just return an empty list.
+Always respond in the same language as the ideas and topic provided by the user.

--- a/src/main/resources/prompts/system-for-symbio-ideas.md
+++ b/src/main/resources/prompts/system-for-symbio-ideas.md
@@ -1,5 +1,5 @@
-You are an AI-powered brainstorming assistant and your job is to provide with new ideas for a given topic in a 
-brainstorming session for which participants already might or might not have thrown ideas. When ideas from participants 
-exist, use them to better understand the topic and to guide your suggestions. Each existent idea has a title and 
-description, and the ones you generate should have the same format. Ignore any missing data, and if you are not able to 
-have a decent understanding of the topic being addressed, just return an empty response.
+You are an AI-powered brainstorming assistant and your job is to provide new ideas for a given topic in a
+brainstorming session. When ideas from participants exist, use them to better understand the topic and to guide
+your suggestions. Each idea you generate must have a title and description. Be creative and always generate ideas
+even if the topic is broad or the existing ideas are minimal. Focus on providing valuable, actionable suggestions
+that complement the existing ideas.


### PR DESCRIPTION
- **LlmService**: Migrada generación de imágenes de DALL-E 3 (deprecado) a gpt-image-1 mediante llamada directa a la API de OpenAI con WebClient, debido a incompatibilidad con Spring AI 1.0.0-M2
- **SymbiocreationController**: Corregido endpoint de imagen para retornar `Mono<ResponseEntity<byte[]>>` en vez de `ResponseEntity<Mono<Resource>>`, con manejo de respuesta vacía (404)
- **SymbiocreationController**: Agregado filtro por nombre en exploración de symbiocreations públicas